### PR TITLE
Feed Respoke auth token to logged in html

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,6 +12,7 @@
     "font-awesome": "~4.3.0",
     "bootstrap-social": "~4.9.0",
     "bootstrap": "~3.3.4",
-    "jquery": "~2.1.4"
+    "jquery": "~2.1.4",
+    "respoke": "~1.34.2"
   }
 }

--- a/index.js
+++ b/index.js
@@ -21,14 +21,18 @@ var resources = {
 var appId = config.get('respoke.appId');
 var appSecret = config.get('respoke.appSecret');
 var baseURL = config.get('respoke.baseURL');
+var roleId = config.get('respoke.roleId');
+var ttl = config.get('respoke.tokenTTLSeconds');
 
-if (appId && appSecret) {
+if (appId && appSecret && baseURL && roleId && ttl) {
   resources.respoke = new RespokeService({
     client: new RespokeClient({
       baseURL: baseURL,
       appId: appId,
       'App-Secret': appSecret
-    })
+    }),
+    roleId: roleId,
+    ttl: ttl
   });
 } else {
   console.warn('Respoke not configured. Please copy config/default.js to config/local.js and ' +

--- a/lib/routes/respoke.js
+++ b/lib/routes/respoke.js
@@ -1,27 +1,14 @@
 'use strict';
 var express = require('express');
-var config = require('config');
 var middleware = require('./middleware');
 var ensureAuthenticated = middleware.ensureAuthenticated;
 var ensureRespokeAvailable = middleware.ensureRespokeAvailable;
 var router = express.Router();
 
 router.get('/respoke/token', ensureAuthenticated, ensureRespokeAvailable, function (req, res, next) {
-  var endpointId = req.user._id;
-  var roleId = config.get('respoke.roleId');
-  var ttl = config.get('respoke.tokenTTLSeconds');
-
-  var params = {
-    endpointId: endpointId,
-    roleId: roleId,
-    ttl: ttl
-  };
-
-  req.resources.respoke.retrieveAuthToken(params).then(function (token) {
+  req.resources.respoke.retrieveAuthToken({ endpointId: req.user._id }).then(function (token) {
     res.status(200).send({ token: token });
-  }).catch(function (err) {
-    next(err);
-  });
+  }).catch(next);
 });
 
 module.exports = router;

--- a/lib/routes/root.js
+++ b/lib/routes/root.js
@@ -1,12 +1,36 @@
 'use strict';
+var url = require('url');
 var express = require('express');
 var passport = require('passport');
 var config = require('config');
 var ensureAuthenticated = require('./middleware').ensureAuthenticated;
 var router = express.Router();
 
-router.get('/', ensureAuthenticated, function (req, res) {
-  res.render('home', { title: 'Home' });
+router.get('/', ensureAuthenticated, function (req, res, next) {
+  if (!req.resources.respoke) {
+    res.render('home', { title: 'Home' });
+    return;
+  }
+
+  return req.resources.respoke.retrieveAuthToken({ endpointId: req.user._id }).then(function (token) {
+    var renderParams = {
+      title: 'Home'
+    };
+
+    var parsedBaseURL = url.parse(req.resources.respoke.baseURL);
+    var clientBaseURL = req.resources.respoke.baseURL.replace(parsedBaseURL.path, '');
+
+    renderParams = {
+      title: 'Home',
+      respoke: {
+        appId: req.resources.respoke.appId,
+        baseURL: clientBaseURL,
+        token: token
+      }
+    };
+
+    res.render('home', renderParams);
+  }).catch(next);
 });
 
 router.get('/login', function (req, res) {

--- a/lib/services/RespokeService.js
+++ b/lib/services/RespokeService.js
@@ -6,15 +6,46 @@ var nodeify = require('nodeify');
  *
  * @param {object} params
  * @param {object} params.client An instantiated Respoke client
+ * @param {string} params.roleId the role id to use when retrieving auth tokens
+ * @param {string} params.ttl the ttl to use when retrieving auth tokens
  * @constructor
  */
 function RespokeService(params) {
-  // make the 'client' property a non-enumerable getter
-  Object.defineProperty(this, 'client', {
-    enumerable: false,
-    configurable: false,
-    get: function () {
-      return params.client;
+  Object.defineProperties(this, {
+    client: {
+      enumerable: false,
+      configurable: false,
+      get: function () {
+        return params.client;
+      }
+    },
+    roleId: {
+      enumerable: false,
+      configurable: false,
+      get: function () {
+        return params.roleId;
+      }
+    },
+    ttl: {
+      enumerable: false,
+      configurable: false,
+      get: function () {
+        return params.ttl;
+      }
+    },
+    appId: {
+      enumerable: true,
+      configurable: false,
+      get: function () {
+        return params.client.appId;
+      }
+    },
+    baseURL: {
+      enumerable: true,
+      configurable: false,
+      get: function () {
+        return params.client.baseURL;
+      }
     }
   });
 }
@@ -24,8 +55,6 @@ function RespokeService(params) {
  *
  * @param {object} params
  * @param {string} params.endpointId the endpointId the token should be assigned
- * @param {string} [params.roleId] the id of the role the token should be assigned
- * @param {number} [params.ttl=86400] the duration (in seconds) that the token should valid
  * @param {function} [callback] signature (err, token)
  * @returns {Promise} if callback is not provided, returns a promise which resolves to the token
  * @memberof RespokeService
@@ -38,8 +67,8 @@ RespokeService.prototype.retrieveAuthToken = function (params, callback) {
 
   var tokenParams = {
     endpointId: params.endpointId,
-    roleId: params.roleId,
-    ttl: params.ttl || 86400 // defaults to 1 day
+    roleId: this.roleId,
+    ttl: this.ttl || 86400 // defaults to 1 day
   };
 
   return this.client.auth.endpoint(tokenParams).then(function (authData) {

--- a/lib/views/_layout.jade
+++ b/lib/views/_layout.jade
@@ -14,3 +14,4 @@ html(lang="en")
       block content
     script(src="bower_components/jquery/dist/jquery.min.js")
     script(src="bower_components/bootstrap/dist/js/bootstrap.min.js")
+    block script

--- a/lib/views/home.jade
+++ b/lib/views/home.jade
@@ -4,8 +4,17 @@ extends ./_layout.jade
   user: { _id, name, email }
 
 block content
+  - var metadata = { user: user, respoke: respoke };
   h1 Welcome!
-  pre!= JSON.stringify(user, null, '\t')
+  pre!= JSON.stringify(metadata, null, '  ')
   a(href="/account") modify your account
   span &nbsp;or&nbsp;
   a(href="/logout") logout
+  div#respokeStatus
+
+block script
+  script var config = { user: !{JSON.stringify(user)} };
+  if respoke
+    script config.respoke = !{JSON.stringify(respoke)};
+  script(src="bower_components/respoke/respoke.min.js")
+  script(src="app.js")

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,42 @@
+/* global
+  $: false,
+  respoke: false,
+  config: false
+ */
+;(function () {
+  'use strict';
+  if (!config.respoke) {
+    return;
+  }
+
+  var $respokeStatus = $('#respokeStatus');
+  respoke.log.setLevel(respoke.log.levels.DEBUG);
+  var client = window.client = respoke.createClient({
+    baseURL: config.respoke.baseURL,
+    appId: config.respoke.appId
+  });
+
+  function reconnect() {
+    $.get('/respoke/token').then(function (res) {
+      return client.connect({ token: res.token });
+    }).then(function () {
+      console.log('Respoke Reconnected!');
+      $respokeStatus.text('Respoke Reconnected!');
+    }).fail(function (err) {
+      console.error(err);
+      $respokeStatus.text('Respoke reconnection failed. See console for details');
+    });
+  }
+
+  client.connect({
+    token: config.respoke.token,
+    onDisconnect: reconnect
+  }).then(function () {
+    console.log('Respoke Connected!');
+    $respokeStatus.text('Respoke Connected!');
+  }).fail(function (err) {
+    console.error(err);
+    $respokeStatus.text('Respoke connection failed. See console for details');
+  });
+
+})();


### PR DESCRIPTION
This patch changes the initial logged in html such that it will
have a token as soon as the page is rendered. This allows the Respoke
client in the browser to immediately connect when the page loads,
instead of having to make a round-trip to the server to fetch a token
first. To show how to use this, I also added a very simple app.js to
demonstrate connecting using the token from the html and then reconnecting
using the API to fetch a fresh token.

Also as a part of this patch, I refactored the RespokeService to accept
the ttl and roleId on the constructor, instead of requiring you to pass
it each time you request an auth token.

Closes #4
